### PR TITLE
fix example config

### DIFF
--- a/apps/yellowstone-fumarole-cli/config_example.toml
+++ b/apps/yellowstone-fumarole-cli/config_example.toml
@@ -1,3 +1,2 @@
-[fumarole]
 endpoints = ["https://fumarole.endpoint.rpcpool.com"]
 x-token = "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
```
fume --config config_example.toml test-config 

thread 'main' panicked at /home/i/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/yellowstone-fumarole-cli-0.1.0-rc6+solana.2/src/bin/fume.rs:743:46:
failed to parse fumarole config: Error("invalid type: sequence, expected struct FumaroleConfig", line: 1, column: 1)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```
After removing the header
```
fume --config config_example.toml test-config 
Successfully connected to Fumarole Service -- version: 0.26.1+solana.2

```