### PR TITLE
fix: popfirst in OrderedSet, source_gen catch

### DIFF
--- a/python/yellowstone-fumarole-client/tests/test_ordered_set.py
+++ b/python/yellowstone-fumarole-client/tests/test_ordered_set.py
@@ -10,7 +10,8 @@ def test_ordered_set():
     assert list(os) == [1, 2, 3]
     assert 2 in os
     assert len(os) == 3
-    os.popfirst()
+    val = os.popfirst()
+    assert val == 1
     assert list(os) == [2, 3]
     assert len(os) == 2
 

--- a/python/yellowstone-fumarole-client/yellowstone_fumarole_client/__init__.py
+++ b/python/yellowstone-fumarole-client/yellowstone_fumarole_client/__init__.py
@@ -282,9 +282,7 @@ class FumaroleClient:
                 while True:
                     update = await dragonsmouth_outlet.get()
                     yield update
-            except asyncio.CancelledError:
-                pass
-            except asyncio.Queue:
+            except (asyncio.CancelledError, asyncio.QueueShutDown):
                 pass
             finally:
                 dragonsmouth_outlet.shutdown()

--- a/python/yellowstone-fumarole-client/yellowstone_fumarole_client/runtime/aio.py
+++ b/python/yellowstone-fumarole-client/yellowstone_fumarole_client/runtime/aio.py
@@ -142,9 +142,9 @@ class AsyncioFumeDragonsmouthRuntime:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.aclose()
+        self.close()
 
-    async def aclose(self):
+    def close(self):
         self.control_plane_tx.shutdown()
         self.dragonsmouth_outlet.shutdown()
         for t, kind in self.inflight_tasks.items():
@@ -373,7 +373,7 @@ class AsyncioFumeDragonsmouthRuntime:
 
             await self._drain_slot_status()
 
-        self.aclose()
+        self.close()
         LOGGER.debug("Fumarole runtime exiting")
 
 

--- a/python/yellowstone-fumarole-client/yellowstone_fumarole_client/runtime/aio.py
+++ b/python/yellowstone-fumarole-client/yellowstone_fumarole_client/runtime/aio.py
@@ -142,9 +142,9 @@ class AsyncioFumeDragonsmouthRuntime:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        self.close()
+        await self.aclose()
 
-    def close(self):
+    async def aclose(self):
         self.control_plane_tx.shutdown()
         self.dragonsmouth_outlet.shutdown()
         for t, kind in self.inflight_tasks.items():
@@ -373,7 +373,7 @@ class AsyncioFumeDragonsmouthRuntime:
 
             await self._drain_slot_status()
 
-        self.close()
+        await self.aclose()
         LOGGER.debug("Fumarole runtime exiting")
 
 

--- a/python/yellowstone-fumarole-client/yellowstone_fumarole_client/utils/collections.py
+++ b/python/yellowstone-fumarole-client/yellowstone_fumarole_client/utils/collections.py
@@ -20,7 +20,7 @@ class OrderedSet:
 
     def popfirst(self):
         try:
-            self.inner.popitem(last=False)
+            return self.inner.popitem(last=False)[0]
         except KeyError as e:
             raise KeyError(f"{OrderedDict.__name__} is empty") from e
 


### PR DESCRIPTION
- ensure that `popfirst` returns a value in OrderedSet, otherwise garbage collection won't work correctly;
- fix error handling in `source_gen`;
- await `aclose` in the `run`;