### PR TITLE
fix: shutdown error typo, use isinstance on update, use suppress, fix typing

### DIFF
--- a/python/yellowstone-fumarole-client/yellowstone_fumarole_client/error.py
+++ b/python/yellowstone-fumarole-client/yellowstone_fumarole_client/error.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from typing import Any, Mapping
 
 
 class FumaroleClientError(Exception):
@@ -14,6 +14,6 @@ class SubscribeError(FumaroleClientError):
 class DownloadSlotError(SubscribeError):
     """Exception raised for errors in the download slot process."""
     
-    def __init__(self, message: str, ctx: Mapping[str, any]):
+    def __init__(self, message: str, ctx: Mapping[str, Any]):
         super().__init__(message)
         self.ctx = ctx


### PR DESCRIPTION
- fix typo when suppressing `ShutDown` asyncio error (previously it was `Shutdown`);
- use suppress instead of empty `try...except` blocks;
- fix typing of `any` (lowercase any is an stdlib callable);
- always pass ctx to `DownloadBlockError` as it's a required property;
- use `isinstance` check for exceptions;