### PR TITLE
fix: remove unused RuntimeError enum

### DIFF
--- a/crates/yellowstone-fumarole-client/src/runtime/tokio.rs
+++ b/crates/yellowstone-fumarole-client/src/runtime/tokio.rs
@@ -121,12 +121,6 @@ const fn build_commit_offset_cmd(offset: FumeOffset) -> ControlCommand {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum RuntimeError {
-    #[error(transparent)]
-    GrpcError(#[from] tonic::Status),
-}
-
 impl From<SubscribeRequest> for BlockFilters {
     fn from(val: SubscribeRequest) -> Self {
         BlockFilters {


### PR DESCRIPTION
## Summary
- Remove unused `RuntimeError` enum in `crates/yellowstone-fumarole-client/src/runtime/tokio.rs`
- Eliminates `dead_code` clippy warning

## Test plan
- [x] `cargo clippy --workspace` produces zero warnings
- [x] `cargo check --workspace` compiles successfully
- [x] `cargo fmt --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)