### PR TITLE
rust: enable sharded download + fixes in typescript and python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,94 +3,10 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "agave-feature-set"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2846bb4fc0831d112255193a54259fabdc82149f0cd0a72db8922837cc62c0cd"
-dependencies = [
- "ahash",
- "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
- "solana-sha256-hasher",
- "solana-svm-feature-set",
-]
-
-[[package]]
-name = "agave-reserved-account-keys"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55fff3d170fbcf81afc8d30c504a1ae4a6ff64be025ee6c08012f3db2a243fc"
-dependencies = [
- "agave-feature-set",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -167,18 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +125,7 @@ dependencies = [
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -249,15 +153,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -313,46 +208,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
-name = "bv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
-dependencies = [
- "feature-probe",
- "serde",
-]
-
-[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -394,17 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cfg_eval"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,16 +262,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -484,19 +322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "combine"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
-dependencies = [
- "ascii",
- "byteorder",
- "either",
- "memchr",
- "unreachable",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,46 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rand_core 0.6.4",
- "rustc_version",
- "serde",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -625,12 +411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivation-path"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,7 +418,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -677,18 +456,6 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 dependencies = [
  "getrandom 0.2.17",
 ]
-
-[[package]]
-name = "feature-probe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -917,15 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,15 +715,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -1128,28 +877,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1184,15 +915,6 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -1256,18 +978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,45 +1026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1368,12 +1045,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1413,15 +1084,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
 ]
 
 [[package]]
@@ -1478,18 +1140,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "powerfmt"
@@ -1588,7 +1238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -1609,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -1729,15 +1379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,33 +1395,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1790,16 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1884,25 +1495,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -1955,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2055,25 +1651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,16 +1739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,92 +1792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc0ed36decb689413b9da5d57f2be49eea5bebb3cf7897015167b0c4336e731"
-dependencies = [
- "bincode",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-instruction-error",
- "solana-pubkey 4.0.0",
- "solana-sdk-ids",
- "solana-sysvar",
-]
-
-[[package]]
-name = "solana-account-decoder"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66939b3e7aa0fab7a523bbb0d0518e3cdbb6a9b8675d5ae3a7bba5c1bef98622"
-dependencies = [
- "Inflector",
- "base64",
- "bincode",
- "bs58",
- "bv",
- "serde",
- "serde_json",
- "solana-account",
- "solana-account-decoder-client-types",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-config-interface",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-instruction",
- "solana-loader-v3-interface",
- "solana-nonce",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar",
- "solana-vote-interface",
- "spl-generic-token",
- "spl-token-2022-interface",
- "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "thiserror 2.0.18",
- "zstd",
-]
-
-[[package]]
-name = "solana-account-decoder-client-types"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcf86e96f5e986687edc572033df43723b885c668fa1a3280753232dc8f3656"
-dependencies = [
- "base64",
- "bs58",
- "serde",
- "serde_json",
- "solana-account",
- "solana-pubkey 3.0.0",
- "zstd",
-]
-
-[[package]]
-name = "solana-account-info"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
-dependencies = [
- "solana-address 2.1.0",
- "solana-program-error",
- "solana-program-memory",
-]
-
-[[package]]
 name = "solana-address"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,37 +1807,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998227476aed49e1c63dec0e89341b768a2cf3bd22913c3ed8baa985cda882c9"
 dependencies = [
  "borsh",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
  "five8",
  "five8_const",
  "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-define-syscall 5.0.0",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
  "wincode",
-]
-
-[[package]]
-name = "solana-address-lookup-table-interface"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8df0b083c10ce32490410f3795016b1b5d9b4d094658c0a5e496753645b7cd"
-dependencies = [
- "bincode",
- "bytemuck",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-instruction-error",
- "solana-pubkey 4.0.0",
- "solana-sdk-ids",
- "solana-slot-hashes",
 ]
 
 [[package]]
@@ -2369,83 +1828,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-borsh"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc402b16657abbfa9991cd5cbfac5a11d809f7e7d28d3bb291baeb088b39060e"
-dependencies = [
- "borsh",
-]
-
-[[package]]
 name = "solana-clock"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb62e9381182459a4520b5fe7fb22d423cae736239a6427fc398a88743d0ed59"
 dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
  "solana-sdk-macro",
- "solana-sysvar-id",
 ]
-
-[[package]]
-name = "solana-commitment-config"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e41a3917076a8b5375809078ae3a6fb76a53e364b596ef8c4265e7f410876f3"
-
-[[package]]
-name = "solana-config-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e401ae56aed512821cc7a0adaa412ff97fecd2dff4602be7b1330d2daec0c4"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-cpi"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
-dependencies = [
- "solana-account-info",
- "solana-define-syscall 4.0.1",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 4.0.0",
- "solana-stable-layout",
-]
-
-[[package]]
-name = "solana-curve25519"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737ede9143c36b8628cc11d920cdb762cd1ccbd7ca904c3bd63b39c58669fe38"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "solana-define-syscall 3.0.0",
- "subtle",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-define-syscall"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
 name = "solana-define-syscall"
@@ -2460,252 +1849,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03aacdd7a61e2109887a7a7f046caebafce97ddf1150f33722eeac04f9039c73"
 
 [[package]]
-name = "solana-derivation-path"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff71743072690fdbdfcdc37700ae1cb77485aaad49019473a81aee099b1e0b8c"
-dependencies = [
- "derivation-path",
- "qstring",
- "uriparse",
-]
-
-[[package]]
-name = "solana-epoch-rewards"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b319a4ed70390af911090c020571f0ff1f4ec432522d05ab89f5c08080381995"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash 3.1.0",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-epoch-schedule"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-fee-calculator"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
-dependencies = [
- "log",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "solana-hash"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
-dependencies = [
- "solana-hash 4.1.0",
-]
-
-[[package]]
 name = "solana-hash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6100d68f90726ddb4d2ac7d00e8b6cf9ce8e4ccdfbb9112b1d766045753241"
-dependencies = [
- "borsh",
- "bytemuck",
- "bytemuck_derive",
- "five8",
- "serde",
- "serde_derive",
- "solana-atomic-u64",
- "solana-sanitize",
- "wincode",
-]
-
-[[package]]
-name = "solana-instruction"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
-dependencies = [
- "bincode",
- "borsh",
- "serde",
- "serde_derive",
- "solana-define-syscall 4.0.1",
- "solana-instruction-error",
- "solana-pubkey 4.0.0",
-]
-
-[[package]]
-name = "solana-instruction-error"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04259e03c05faf38a8c24217b5cfe4c90572ae6184ab49cddb1584fdd756d3f"
-dependencies = [
- "num-traits",
- "serde",
- "serde_derive",
- "solana-program-error",
-]
-
-[[package]]
-name = "solana-instructions-sysvar"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
-dependencies = [
- "bitflags",
- "solana-account-info",
- "solana-instruction",
- "solana-instruction-error",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-serialize-utils",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-last-restart-slot"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-loader-v2-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4a6f0ad4fd9c30679bfee2ce3ea6a449cac38049f210480b751f65676dfe82"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee44c9b1328c5c712c68966fb8de07b47f3e7bac006e74ddd1bb053d3e46e5d"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-message"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
-dependencies = [
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-address 2.1.0",
- "solana-hash 4.1.0",
- "solana-instruction",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-transaction-error",
-]
-
-[[package]]
-name = "solana-msg"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
-dependencies = [
- "solana-define-syscall 3.0.0",
-]
-
-[[package]]
-name = "solana-nonce"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbdc6c8caf1c08db9f36a50967539d0f72b9f1d4aea04fec5430f532e5afadc"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-fee-calculator",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
- "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-program-entrypoint"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c9b0a1ff494e05f503a08b3d51150b73aa639544631e510279d6375f290997"
-dependencies = [
- "solana-account-info",
- "solana-define-syscall 4.0.1",
- "solana-program-error",
- "solana-pubkey 4.0.0",
-]
 
 [[package]]
 name = "solana-program-error"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
-dependencies = [
- "borsh",
-]
-
-[[package]]
-name = "solana-program-memory"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
-dependencies = [
- "solana-define-syscall 4.0.1",
-]
-
-[[package]]
-name = "solana-program-option"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7b4ddb464f274deb4a497712664c3b612e3f5f82471d4e47710fc4ab1c3095"
-
-[[package]]
-name = "solana-program-pack"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c169359de21f6034a63ebf96d6b380980307df17a8d371344ff04a883ec4e9d0"
-dependencies = [
- "solana-program-error",
-]
 
 [[package]]
 name = "solana-pubkey"
@@ -2717,65 +1870,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-pubkey"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
-dependencies = [
- "solana-address 2.1.0",
-]
-
-[[package]]
-name = "solana-rent"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-reward-info"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "solana-sanitize"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
-
-[[package]]
-name = "solana-sbpf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
-dependencies = [
- "byteorder",
- "combine",
- "hash32",
- "log",
- "rustc-demangle",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-sdk-ids"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
-dependencies = [
- "solana-address 2.1.0",
-]
 
 [[package]]
 name = "solana-sdk-macro"
@@ -2790,46 +1888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-seed-derivable"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
-dependencies = [
- "solana-derivation-path",
-]
-
-[[package]]
-name = "solana-seed-phrase"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
-dependencies = [
- "hmac",
- "pbkdf2",
- "sha2",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5174c57d5ff3c1995f274d17156964664566e2cde18a07bba1586d35a70d3b"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-serialize-utils"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e41dd8feea239516c623a02f0a81c2367f4b604d7965237fed0751aeec33ed"
-dependencies = [
- "solana-instruction-error",
- "solana-pubkey 3.0.0",
- "solana-sanitize",
-]
-
-[[package]]
 name = "solana-sha256-hasher"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,16 +1895,7 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.1.0",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3bd991c2cc415291c86bb0b6b4d53e93d13bb40344e4c5a2884e0e4f5fa93f"
-dependencies = [
- "serde_core",
+ "solana-hash",
 ]
 
 [[package]]
@@ -2857,318 +1906,8 @@ checksum = "f4028aeedd443d80f1dccbf64872593a80e6a9676ee9007f6eccb63b65983ebd"
 dependencies = [
  "five8",
  "serde",
- "serde-big-array",
- "serde_derive",
  "solana-sanitize",
  "wincode",
-]
-
-[[package]]
-name = "solana-signer"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
-dependencies = [
- "solana-pubkey 3.0.0",
- "solana-signature",
- "solana-transaction-error",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a293f952293281443c04f4d96afd9d547721923d596e92b4377ed2360f1746"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash 3.1.0",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-slot-history"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
-dependencies = [
- "bv",
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-stable-layout"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
-dependencies = [
- "solana-instruction",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "solana-stake-interface"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
-dependencies = [
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-cpi",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-svm-feature-set"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641cddc667abba4cf3474d850a073c0a2b439ff0014c445cd09eaf5d79d70bab"
-
-[[package]]
-name = "solana-system-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
-dependencies = [
- "num-traits",
- "serde",
- "serde_derive",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "solana-sysvar"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
-dependencies = [
- "base64",
- "bincode",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall 4.0.1",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash 4.1.0",
- "solana-instruction",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey 4.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-sysvar-id"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
-dependencies = [
- "solana-address 2.1.0",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96697cff5075a028265324255efed226099f6d761ca67342b230d09f72cc48d2"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-address 2.1.0",
- "solana-hash 4.1.0",
- "solana-instruction",
- "solana-instruction-error",
- "solana-message",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-signature",
- "solana-transaction-error",
-]
-
-[[package]]
-name = "solana-transaction-context"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55a9c2e2af954fae402f08e210c7f01d6a8517ad358f8f0db11ed7de89b02d4"
-dependencies = [
- "bincode",
- "serde",
- "solana-account",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sbpf",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4222065402340d7e6aec9dc3e54d22992ddcf923d91edcd815443c2bfca3144a"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-instruction-error",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-transaction-status"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe59d2c9a9ff1bb05150ebc5b1a945642760977da3715b9e1c403f0a29d3805"
-dependencies = [
- "Inflector",
- "agave-reserved-account-keys",
- "base64",
- "bincode",
- "borsh",
- "bs58",
- "log",
- "serde",
- "serde_json",
- "solana-account-decoder",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-message",
- "solana-program-option",
- "solana-pubkey 3.0.0",
- "solana-reward-info",
- "solana-sdk-ids",
- "solana-signature",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-transaction",
- "solana-transaction-error",
- "solana-transaction-status-client-types",
- "solana-vote-interface",
- "spl-associated-token-account-interface",
- "spl-memo-interface",
- "spl-token-2022-interface",
- "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-transaction-status-client-types"
-version = "3.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1341840c0ba1028b918b03c9ba9900019f739ee23946baf76574ec0a5dab8231"
-dependencies = [
- "base64",
- "bincode",
- "bs58",
- "serde",
- "serde_json",
- "solana-account-decoder-client-types",
- "solana-commitment-config",
- "solana-instruction",
- "solana-message",
- "solana-pubkey 3.0.0",
- "solana-reward-info",
- "solana-signature",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
-dependencies = [
- "bincode",
- "cfg_eval",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "serde_with",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-instruction-error",
- "solana-pubkey 3.0.0",
- "solana-rent",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-zk-sdk"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9602bcb1f7af15caef92b91132ec2347e1c51a72ecdbefdaefa3eac4b8711475"
-dependencies = [
- "aes-gcm-siv",
- "base64",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "getrandom 0.2.17",
- "itertools 0.12.1",
- "js-sys",
- "merlin",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
- "subtle",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -3178,226 +1917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spl-associated-token-account-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
-dependencies = [
- "borsh",
- "solana-instruction",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cc11459e265d5b501534144266620289720b4c44522a47bc6b63cd295d2f3"
-dependencies = [
- "bytemuck",
- "solana-program-error",
- "solana-sha256-hasher",
- "spl-discriminator-derive",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
-dependencies = [
- "quote",
- "spl-discriminator-syn",
- "syn",
-]
-
-[[package]]
-name = "spl-discriminator-syn"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1dbc82ab91422345b6df40a79e2b78c7bce1ebb366da323572dd60b7076b67"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2",
- "syn",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-generic-token"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233df81b75ab99b42f002b5cdd6e65a7505ffa930624f7096a7580a56765e9cf"
-dependencies = [
- "bytemuck",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "spl-memo-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4e2aedd58f858337fa609af5ad7100d4a243fdaf6a40d6eb4c28c5f19505d3"
-dependencies = [
- "solana-instruction",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1233fdecd7461611d69bb87bc2e95af742df47291975d21232a0be8217da9de"
-dependencies = [
- "borsh",
- "bytemuck",
- "bytemuck_derive",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program-error",
- "solana-program-option",
- "solana-pubkey 3.0.0",
- "solana-zk-sdk",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-2022-interface"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcd81188211f4b3c8a5eba7fd534c7142f9dd026123b3472492782cc72f4dc6"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-zk-sdk",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-type-length-value",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879a9ebad0d77383d3ea71e7de50503554961ff0f4ef6cbca39ad126e6f6da3a"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-curve25519",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-zk-sdk",
- "spl-pod",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cd59fce3dc00f563c6fa364d67c3f200d278eae681f4dc250240afcfe044b1"
-dependencies = [
- "curve25519-dalek",
- "solana-zk-sdk",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452d0f758af20caaa10d9a6f7608232e000d4c74462f248540b3d2ddfa419776"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "spl-discriminator",
- "spl-pod",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-instruction",
- "solana-program-error",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c467c7c3bd056f8fe60119e7ec34ddd6f23052c2fa8f1f51999098063b72676"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "spl-discriminator",
- "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca20a1a19f4507a98ca4b28ff5ed54cac9b9d34ed27863e2bde50a3238f9a6ac"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-msg",
- "solana-program-error",
- "spl-discriminator",
- "spl-pod",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3708,7 +2227,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3769,6 +2288,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -3804,6 +2338,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3896,25 +2431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,16 +2441,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "uriparse"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
-dependencies = [
- "fnv",
- "lazy_static",
-]
 
 [[package]]
 name = "utf8parse"
@@ -3964,12 +2470,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"
@@ -4421,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-fumarole-cli"
-version = "0.2.0+solana.3"
+version = "0.3.0+solana.3"
 dependencies = [
  "bs58",
  "clap",
@@ -4433,7 +2933,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_yaml",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-signature",
  "tabled",
  "thiserror 2.0.18",
@@ -4450,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-fumarole-client"
-version = "0.3.2+solana.3"
+version = "0.4.0+solana.3"
 dependencies = [
  "async-trait",
  "bytesize",
@@ -4462,8 +2962,9 @@ dependencies = [
  "prometheus",
  "prost",
  "protoc-bin-vendored",
- "rand 0.9.2",
+ "rand",
  "rustc-hash",
+ "semver",
  "serde",
  "serde_json",
  "serde_with",
@@ -4476,7 +2977,7 @@ dependencies = [
  "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "uuid",
  "yellowstone-grpc-proto",
@@ -4489,7 +2990,7 @@ dependencies = [
  "bs58",
  "clap",
  "serde_yaml",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-signature",
  "thiserror 2.0.18",
  "tokio",
@@ -4502,42 +3003,32 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "11.0.0"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4024d13119c2b12e02829ed8e38dc676200cc0b0f5384bda94af7e47097a2ac"
+checksum = "32b250b0ed11fb0fb11b80e89599e6f5a77640bce3dafe26ffb8022cdfc6c49e"
 dependencies = [
  "bytes",
  "futures",
+ "hyper-util",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-health",
+ "tower 0.4.13",
  "yellowstone-grpc-proto",
 ]
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "11.0.0"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc56c7739daf7410bf6ef04ce71ce9b9a22483ef73b78a873815f87e9a8d1d2f"
+checksum = "ab52445da59c3e710dd2128e3e49598cfa45c8ba7f30feb608cafbd404e5e8cf"
 dependencies = [
  "anyhow",
- "bincode",
  "prost",
  "prost-types",
  "protoc-bin-vendored",
- "solana-account",
- "solana-account-decoder",
- "solana-clock",
- "solana-hash 4.1.0",
- "solana-message",
- "solana-pubkey 4.0.0",
- "solana-signature",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error",
- "solana-transaction-status",
  "tonic",
- "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -4567,20 +3058,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = "1.0.203"
 serde_json = "~1.0.142"
 serde_with = "^3.8.1"
 serde_yaml = "~0.9.34"
+semver = "1.0.27"
 solana-clock = "3.0.0"
 solana-pubkey = "3.0.0"
 solana-signature = "3.0.0"
@@ -53,9 +54,9 @@ tower = "~0.5.2"
 tracing = "~0.1.41"
 tracing-subscriber = { version = "~0.3.18", features = ["env-filter"] }
 uuid = { version = "1" }
-yellowstone-fumarole-client = { path = "crates/yellowstone-fumarole-client", version = "0.3.1+solana.3" }
-yellowstone-grpc-client = "11.0.0"
-yellowstone-grpc-proto = "11.0.0"
+yellowstone-fumarole-client = { path = "crates/yellowstone-fumarole-client", version = "0.4.0+solana.3" }
+yellowstone-grpc-client = "12.0.0"
+yellowstone-grpc-proto = "12.0.0"
 
 [workspace.lints.clippy]
 clone_on_ref_ptr = "deny"

--- a/apps/yellowstone-fumarole-cli/Cargo.toml
+++ b/apps/yellowstone-fumarole-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yellowstone-fumarole-cli"
 description = "Yellowstone Fumarole CLI"
-version = "0.2.0+solana.3"
+version = "0.3.0+solana.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/apps/yellowstone-fumarole-cli/src/bin/fume.rs
+++ b/apps/yellowstone-fumarole-cli/src/bin/fume.rs
@@ -14,7 +14,7 @@ use {
         hash::Hash,
         io::{Write, stdout},
         net::{AddrParseError, SocketAddr},
-        num::NonZeroU8,
+        num::{NonZeroU8, NonZeroUsize},
         path::PathBuf,
         str::FromStr,
         time::Duration,
@@ -55,8 +55,17 @@ pub struct FumeConfig {
     fumarole: FumaroleConfig,
 
     // Experimental(xx) feature to enable sharded downloads
-    #[serde(default)]
-    xx_enable_sharded_download: bool,
+    #[serde(
+        default = "FumeConfig::default_enable_sharded_download",
+        alias = "xx_enable_sharded_download"
+    )]
+    enable_sharded_download: bool,
+}
+
+impl FumeConfig {
+    const fn default_enable_sharded_download() -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -371,6 +380,10 @@ struct SubscribeArgs {
     /// Number of parallel data streams (TCP connections) to open to fumarole.
     #[clap(long, short, default_value = "1")]
     para: NonZeroU8,
+
+    /// Number of concurrent shard download per TCP connection. Only applicable when xx_enable_sharded_download is true.
+    #[clap(long, default_value = "1")]
+    con: NonZeroUsize,
 
     /// If true, the fumarole client will not commit offsets to the fumarole service.
     #[clap(long, default_value = "false")]
@@ -720,7 +733,8 @@ async fn subscribe(
         commit_interval: Duration::from_secs(1),
         num_data_plane_tcp_connections: args.para,
         no_commit: args.no_commit,
-        experimental_enable_sharded_block_download: xx_enable_sharded_download,
+        enable_sharded_block_download: xx_enable_sharded_download,
+        concurrent_download_limit_per_tcp: args.con,
         ..Default::default()
     };
     let dragonsmouth_session = client
@@ -839,7 +853,7 @@ async fn block_stats(
         commit_interval: Duration::from_secs(5),
         num_data_plane_tcp_connections: args.para,
         no_commit: args.no_commit,
-        experimental_enable_sharded_block_download: xx_enable_sharded_download,
+        enable_sharded_block_download: xx_enable_sharded_download,
         ..Default::default()
     };
     let dragonsmouth_session = client
@@ -936,7 +950,9 @@ async fn block_stats(
                         }
                         UpdateOneof::BlockMeta(block_meta) => {
                             let slot = block_meta.slot;
-                            let mut block = block_map.remove(&slot).expect("Failed to get block info");
+                            let Some(mut block) = block_map.remove(&slot) else {
+                                continue;
+                            };
                             block.block_meta = Some(block_meta);
                             let msg = summarized_block(&block);
                             block_count_per_tick += 1;
@@ -1074,7 +1090,7 @@ async fn main() {
             subscribe(
                 fumarole_client,
                 subscribe_args,
-                config.xx_enable_sharded_download,
+                config.enable_sharded_download,
             )
             .await;
         }
@@ -1082,12 +1098,7 @@ async fn main() {
             slot_range(fumarole_client).await;
         }
         Action::Block(blocks_args) => {
-            block_stats(
-                fumarole_client,
-                blocks_args,
-                config.xx_enable_sharded_download,
-            )
-            .await;
+            block_stats(fumarole_client, blocks_args, config.enable_sharded_download).await;
         }
     }
 }

--- a/crates/yellowstone-fumarole-client/Cargo.toml
+++ b/crates/yellowstone-fumarole-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yellowstone-fumarole-client"
 description = "Yellowstone Fumarole Client"
-version = "0.3.2+solana.3"
+version = "0.4.0+solana.3"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
@@ -36,6 +36,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
+semver = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tokio-stream = { workspace = true }

--- a/crates/yellowstone-fumarole-client/src/config.rs
+++ b/crates/yellowstone-fumarole-client/src/config.rs
@@ -28,7 +28,7 @@ pub struct FumaroleConfig {
     /// If set, the client will accept compressed responses using this encoding
     /// Supported values are "gzip" and "zstd"
     #[serde(
-        default = "FumaroleConfig::no_compression",
+        default = "FumaroleConfig::default_response_compression",
         alias = "response-compression",
         deserialize_with = "FumaroleConfig::deser_compression"
     )]
@@ -72,6 +72,10 @@ impl FumaroleConfig {
         None
     }
 
+    const fn default_response_compression() -> Option<CompressionEncoding> {
+        Some(CompressionEncoding::Zstd)
+    }
+
     ///
     /// Deserialize the [`CompressionEncoding`] field from a string
     ///
@@ -83,6 +87,7 @@ impl FumaroleConfig {
         match value {
             Some(ref s) if s == "gzip" => Ok(Some(CompressionEncoding::Gzip)),
             Some(ref s) if s == "zstd" => Ok(Some(CompressionEncoding::Zstd)),
+            Some(ref s) if s == "none" => Ok(None),
             Some(_) => Err(serde::de::Error::custom("Invalid compression encoding")),
             None => Ok(None),
         }

--- a/crates/yellowstone-fumarole-client/src/lib.rs
+++ b/crates/yellowstone-fumarole-client/src/lib.rs
@@ -286,6 +286,7 @@ use {
             TokioFumeDragonsmouthRuntime,
         },
     },
+    semver::Version,
     std::{
         collections::HashMap,
         num::{NonZeroU8, NonZeroUsize},
@@ -495,12 +496,15 @@ pub struct FumaroleSubscribeConfig {
     /// If set to `true`, [`FumaroleSubscribeConfig::commit_interval`] will be ignored.
     pub no_commit: bool,
 
-    pub experimental_enable_sharded_block_download: bool,
+    ///
+    /// Whether to enable sharded block download. If enabled, the fumarole will download block in shards and reassemble them in the client.
+    /// set to `true` by default.
+    ///
+    pub enable_sharded_block_download: bool,
 }
 
 impl Default for FumaroleSubscribeConfig {
     fn default() -> Self {
-        #[allow(deprecated)]
         Self {
             num_data_plane_tcp_connections: NonZeroU8::new(DEFAULT_PARA_DATA_STREAMS).unwrap(),
             concurrent_download_limit_per_tcp: NonZeroUsize::new(
@@ -514,7 +518,7 @@ impl Default for FumaroleSubscribeConfig {
             slot_memory_retention: DEFAULT_SLOT_MEMORY_RETENTION,
             refresh_tip_stats_interval: DEFAULT_REFRESH_TIP_INTERVAL, // Default to 5 seconds
             no_commit: false,
-            experimental_enable_sharded_block_download: false,
+            enable_sharded_block_download: true,
         }
     }
 }
@@ -676,6 +680,35 @@ impl FumaroleClient {
     where
         S: AsRef<str>,
     {
+        let version = self.version().await?;
+        let semver_version = Version::parse(&version.version).ok();
+        if let Some(semver_version) = &semver_version {
+            tracing::debug!("Fumarole service version: {}", semver_version);
+        } else {
+            tracing::warn!(
+                "Failed to parse fumarole service version: {}",
+                version.version
+            );
+        }
+        const SHARDED_DOWNLOAD_MINIMUM_MINOR_VERSION: u64 = 39;
+        let use_sharded_downlaod = config.enable_sharded_block_download
+            && semver_version
+                .filter(|v| v.minor > SHARDED_DOWNLOAD_MINIMUM_MINOR_VERSION)
+                .is_none();
+
+        if config.enable_sharded_block_download && !use_sharded_downlaod {
+            tracing::warn!(
+                "Sharded block download is enabled in the config, but the fumarole service version {} does not support it. Falling back to non-sharded download.",
+                version.version
+            );
+        }
+
+        if use_sharded_downlaod {
+            tracing::debug!("using sharded block download");
+        } else {
+            tracing::debug!("using non-sharded block download");
+        }
+
         let request = Arc::new(request);
         assert!(
             config.num_data_plane_tcp_connections.get() <= MAX_PARA_DATA_STREAMS,
@@ -707,7 +740,7 @@ impl FumaroleClient {
             .await
             .expect("failed to send initial join");
 
-        let resp = if config.experimental_enable_sharded_block_download {
+        let resp = if use_sharded_downlaod {
             self.inner
                 .subscribe_v2(ReceiverStream::new(fume_control_plane_rx))
                 .await?
@@ -761,7 +794,7 @@ impl FumaroleClient {
         let (download_task_queue_tx, download_task_queue_rx) = mpsc::channel(100);
         let (download_result_tx, download_result_rx) = mpsc::channel(1000);
 
-        let download_task_runner_jh = if config.experimental_enable_sharded_block_download {
+        let download_task_runner_jh = if use_sharded_downlaod {
             let grpc_download_task_runner = runtime::tokio::GrpcShardedDownloadOrchestrator::new(
                 data_plane_channel_vec,
                 self.connector.clone(),
@@ -770,6 +803,7 @@ impl FumaroleClient {
                 download_result_tx,
                 config.max_failed_slot_download_attempt,
                 Arc::clone(&request),
+                config.concurrent_download_limit_per_tcp,
                 dragonsmouth_outlet.clone(),
             );
             handle.spawn(grpc_download_task_runner.run())
@@ -816,8 +850,7 @@ impl FumaroleClient {
             last_history_poll: Default::default(),
             no_commit: config.no_commit,
             stop: false,
-            experimental_enable_sharded_block_download: config
-                .experimental_enable_sharded_block_download,
+            enable_sharded_block_download: use_sharded_downlaod,
         };
         let fumarole_rt_jh = handle.spawn(tokio_rt.run());
         let fut = async move {

--- a/crates/yellowstone-fumarole-client/src/runtime/tokio.rs
+++ b/crates/yellowstone-fumarole-client/src/runtime/tokio.rs
@@ -22,6 +22,7 @@ use {
     solana_clock::Slot,
     std::{
         collections::{HashMap, VecDeque},
+        num::NonZeroUsize,
         sync::Arc,
         time::{Duration, Instant},
     },
@@ -94,7 +95,7 @@ pub(crate) struct TokioFumeDragonsmouthRuntime {
     pub non_critical_background_jobs: JoinSet<BackgroundJobResult>,
     pub no_commit: bool,
     pub stop: bool,
-    pub experimental_enable_sharded_block_download: bool,
+    pub enable_sharded_block_download: bool,
 }
 
 const DEFAULT_HISTORY_POLL_SIZE: i64 = 100;
@@ -121,12 +122,6 @@ const fn build_commit_offset_cmd(offset: FumeOffset) -> ControlCommand {
             },
         )),
     }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum RuntimeError {
-    #[error(transparent)]
-    GrpcError(#[from] tonic::Status),
 }
 
 impl From<SubscribeRequest> for BlockFilters {
@@ -380,7 +375,7 @@ impl TokioFumeDragonsmouthRuntime {
             .await
             .expect("failed to send initial join");
 
-        let resp = if self.experimental_enable_sharded_block_download {
+        let resp = if self.enable_sharded_block_download {
             self.fumarole_client
                 .inner
                 .subscribe_v2(ReceiverStream::new(fume_control_plane_rx))
@@ -1245,7 +1240,7 @@ impl GrpcContinuousShardDownloader {
         ));
 
         let err = loop {
-            let poll_shared_queue = self.shard_scheduled_for_download.len() <= 1;
+            let poll_shared_queue = self.shard_scheduled_for_download.len() < 2;
             tokio::select! {
                 maybe = self.cnc_rx.recv() => {
                     match maybe {
@@ -1373,6 +1368,7 @@ pub(crate) struct GrpcShardedDownloadOrchestrator {
     max_download_attempt_per_slot: usize,
     subscribe_request: Arc<SubscribeRequest>,
     dragonsmouth_outlet: mpsc::Sender<Result<SubscribeUpdate, tonic::Status>>,
+    concurrent_shard_download_scaler: NonZeroUsize,
 }
 
 ///
@@ -1394,6 +1390,7 @@ impl GrpcShardedDownloadOrchestrator {
         outlet: mpsc::Sender<DownloadTaskResult>,
         max_download_attempt_by_slot: usize,
         subscribe_request: Arc<SubscribeRequest>,
+        concurrent_shard_download_scaler: NonZeroUsize,
         dragonsmouth_outlet: mpsc::Sender<Result<SubscribeUpdate, tonic::Status>>,
     ) -> Self {
         let num_data_plane_clients = data_plane_channel_vec.len();
@@ -1414,6 +1411,7 @@ impl GrpcShardedDownloadOrchestrator {
             shared_shard_download_queue_rx,
             slot_download_progression_map: HashMap::new(),
             dragonsmouth_outlet,
+            concurrent_shard_download_scaler,
             completed_tx,
             completed_rx,
         }
@@ -1662,7 +1660,15 @@ impl GrpcShardedDownloadOrchestrator {
     }
 
     pub(crate) async fn run(mut self) -> Result<(), DownloadBlockError> {
-        for (client_idx, client) in self.data_plane_channel_vec.iter().enumerate() {
+        let total_shard_downloader =
+            self.data_plane_channel_vec.len() * self.concurrent_shard_download_scaler.get();
+        for (client_idx, client) in self
+            .data_plane_channel_vec
+            .iter()
+            .enumerate()
+            .cycle()
+            .take(total_shard_downloader)
+        {
             let (cnc_tx, cnc_rx) = mpsc::channel(10);
             let shard_downloader = GrpcContinuousShardDownloader {
                 cnc_rx,

--- a/deny.toml
+++ b/deny.toml
@@ -3,29 +3,4 @@ all-features = true
 
 [advisories]
 ignore = [
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2022-0093
-    # Versions of `ed25519-dalek` prior to v2.0 model private and public keys as
-    # separate types which can be assembled into a `Keypair`, and also provide APIs
-    # for serializing and deserializing 64-byte private/public keypairs.
-    # 
-    # Such APIs and serializations are inherently unsafe as the public key is one of
-    # the inputs used in the deterministic computation of the `S` part of the signature,
-    # but not in the `R` value. An adversary could somehow use the signing function as
-    # an oracle that allows arbitrary public keys as input can obtain two signatures
-    # for the same message sharing the same `R` and only differ on the `S` part.
-    # 
-    # Unfortunately, when this happens, one can easily extract the private key.
-    "RUSTSEC-2022-0093",
-
-    # Timing variability of any kind is problematic when working with  potentially secret values such as
-    # elliptic curve scalars, and such issues can potentially leak private keys and other secrets. Such a
-    # problem was recently discovered in `curve25519-dalek`.
-    "RUSTSEC-2024-0344",
-
-    # ID: RUSTSEC-2025-0141
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0141
-    # Due to a doxxing and harassment incident, the bincode team has taken the decision to cease development permanently.
-    
-    # The team considers version 1.3.3 a complete version of bincode that is not in need of any updates.
-    "RUSTSEC-2025-0141",
 ]

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,19 @@
+# Usage
+
+Install `tsx` globally `npm i -g tsx`
+
+Specify an dotenv file (`.env`) with two to environment variable:
+
+```
+FUMAROLE_ENDPOINT="https://ams.rpcpool.com"
+FUMAROLE_X_TOKEN="<YOUR X_TOKEN>"
+FUMAROLE_CLIENT_LOG_LEVEL="info"
+```
+
+```sh
+cd typescript-sdk && pnpm install && pnpm run build
+cd ../examples/typescript
+pnpm install
+
+tsx src/subscribe-token-transactions.ts 
+```

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triton-one/yellowstone-fumarole",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "Apache-2.0",
   "author": "Triton One",
   "description": "Yellowstone gRPC Fumarole Node.js Client",

--- a/typescript-sdk/src/grpc/fumarole.ts
+++ b/typescript-sdk/src/grpc/fumarole.ts
@@ -161,6 +161,7 @@ export interface DownloadBlockShard {
   blockUid: Uint8Array;
   shardIdx: number;
   blockFilters?: BlockFilters | undefined;
+  slot?: bigint | undefined;
 }
 
 export interface Ping {
@@ -177,6 +178,9 @@ export interface DataCommand {
 }
 
 export interface BlockShardDownloadFinish {
+  blockUid: Uint8Array;
+  slot: bigint;
+  shardIndices: number[];
 }
 
 export interface BlockNotFound {
@@ -1726,7 +1730,13 @@ export const BlockFilters_BlocksMetaEntry: MessageFns<BlockFilters_BlocksMetaEnt
 };
 
 function createBaseDownloadBlockShard(): DownloadBlockShard {
-  return { blockchainId: new Uint8Array(0), blockUid: new Uint8Array(0), shardIdx: 0, blockFilters: undefined };
+  return {
+    blockchainId: new Uint8Array(0),
+    blockUid: new Uint8Array(0),
+    shardIdx: 0,
+    blockFilters: undefined,
+    slot: undefined,
+  };
 }
 
 export const DownloadBlockShard: MessageFns<DownloadBlockShard> = {
@@ -1742,6 +1752,12 @@ export const DownloadBlockShard: MessageFns<DownloadBlockShard> = {
     }
     if (message.blockFilters !== undefined) {
       BlockFilters.encode(message.blockFilters, writer.uint32(34).fork()).join();
+    }
+    if (message.slot !== undefined) {
+      if (BigInt.asUintN(64, message.slot) !== message.slot) {
+        throw new globalThis.Error("value provided for field message.slot of type uint64 too large");
+      }
+      writer.uint32(40).uint64(message.slot);
     }
     return writer;
   },
@@ -1785,6 +1801,14 @@ export const DownloadBlockShard: MessageFns<DownloadBlockShard> = {
           message.blockFilters = BlockFilters.decode(reader, reader.uint32());
           continue;
         }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.slot = reader.uint64() as bigint;
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1800,6 +1824,7 @@ export const DownloadBlockShard: MessageFns<DownloadBlockShard> = {
       blockUid: isSet(object.blockUid) ? bytesFromBase64(object.blockUid) : new Uint8Array(0),
       shardIdx: isSet(object.shardIdx) ? globalThis.Number(object.shardIdx) : 0,
       blockFilters: isSet(object.blockFilters) ? BlockFilters.fromJSON(object.blockFilters) : undefined,
+      slot: isSet(object.slot) ? BigInt(object.slot) : undefined,
     };
   },
 
@@ -1817,6 +1842,9 @@ export const DownloadBlockShard: MessageFns<DownloadBlockShard> = {
     if (message.blockFilters !== undefined) {
       obj.blockFilters = BlockFilters.toJSON(message.blockFilters);
     }
+    if (message.slot !== undefined) {
+      obj.slot = message.slot.toString();
+    }
     return obj;
   },
 
@@ -1831,6 +1859,7 @@ export const DownloadBlockShard: MessageFns<DownloadBlockShard> = {
     message.blockFilters = (object.blockFilters !== undefined && object.blockFilters !== null)
       ? BlockFilters.fromPartial(object.blockFilters)
       : undefined;
+    message.slot = object.slot ?? undefined;
     return message;
   },
 };
@@ -2034,11 +2063,25 @@ export const DataCommand: MessageFns<DataCommand> = {
 };
 
 function createBaseBlockShardDownloadFinish(): BlockShardDownloadFinish {
-  return {};
+  return { blockUid: new Uint8Array(0), slot: 0n, shardIndices: [] };
 }
 
 export const BlockShardDownloadFinish: MessageFns<BlockShardDownloadFinish> = {
-  encode(_: BlockShardDownloadFinish, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(message: BlockShardDownloadFinish, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.blockUid.length !== 0) {
+      writer.uint32(10).bytes(message.blockUid);
+    }
+    if (message.slot !== 0n) {
+      if (BigInt.asUintN(64, message.slot) !== message.slot) {
+        throw new globalThis.Error("value provided for field message.slot of type uint64 too large");
+      }
+      writer.uint32(16).uint64(message.slot);
+    }
+    writer.uint32(26).fork();
+    for (const v of message.shardIndices) {
+      writer.uint32(v);
+    }
+    writer.join();
     return writer;
   },
 
@@ -2049,6 +2092,40 @@ export const BlockShardDownloadFinish: MessageFns<BlockShardDownloadFinish> = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.blockUid = reader.bytes();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.slot = reader.uint64() as bigint;
+          continue;
+        }
+        case 3: {
+          if (tag === 24) {
+            message.shardIndices.push(reader.uint32());
+
+            continue;
+          }
+
+          if (tag === 26) {
+            const end2 = reader.uint32() + reader.pos;
+            while (reader.pos < end2) {
+              message.shardIndices.push(reader.uint32());
+            }
+
+            continue;
+          }
+
+          break;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2058,20 +2135,38 @@ export const BlockShardDownloadFinish: MessageFns<BlockShardDownloadFinish> = {
     return message;
   },
 
-  fromJSON(_: any): BlockShardDownloadFinish {
-    return {};
+  fromJSON(object: any): BlockShardDownloadFinish {
+    return {
+      blockUid: isSet(object.blockUid) ? bytesFromBase64(object.blockUid) : new Uint8Array(0),
+      slot: isSet(object.slot) ? BigInt(object.slot) : 0n,
+      shardIndices: globalThis.Array.isArray(object?.shardIndices)
+        ? object.shardIndices.map((e: any) => globalThis.Number(e))
+        : [],
+    };
   },
 
-  toJSON(_: BlockShardDownloadFinish): unknown {
+  toJSON(message: BlockShardDownloadFinish): unknown {
     const obj: any = {};
+    if (message.blockUid.length !== 0) {
+      obj.blockUid = base64FromBytes(message.blockUid);
+    }
+    if (message.slot !== 0n) {
+      obj.slot = message.slot.toString();
+    }
+    if (message.shardIndices?.length) {
+      obj.shardIndices = message.shardIndices.map((e) => Math.round(e));
+    }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<BlockShardDownloadFinish>, I>>(base?: I): BlockShardDownloadFinish {
     return BlockShardDownloadFinish.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<BlockShardDownloadFinish>, I>>(_: I): BlockShardDownloadFinish {
+  fromPartial<I extends Exact<DeepPartial<BlockShardDownloadFinish>, I>>(object: I): BlockShardDownloadFinish {
     const message = createBaseBlockShardDownloadFinish();
+    message.blockUid = object.blockUid ?? new Uint8Array(0);
+    message.slot = object.slot ?? 0n;
+    message.shardIndices = object.shardIndices?.map((e) => e) || [];
     return message;
   },
 };
@@ -3520,6 +3615,15 @@ export const FumaroleService = {
     responseSerialize: (value: DataResponse): Buffer => Buffer.from(DataResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): DataResponse => DataResponse.decode(value),
   },
+  downloadBlockDataShard: {
+    path: "/fumarole.Fumarole/DownloadBlockDataShard",
+    requestStream: false,
+    responseStream: true,
+    requestSerialize: (value: DownloadBlockShard): Buffer => Buffer.from(DownloadBlockShard.encode(value).finish()),
+    requestDeserialize: (value: Buffer): DownloadBlockShard => DownloadBlockShard.decode(value),
+    responseSerialize: (value: DataResponse): Buffer => Buffer.from(DataResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): DataResponse => DataResponse.decode(value),
+  },
   /** Represents subscription to the data plane */
   subscribeData: {
     path: "/fumarole.Fumarole/SubscribeData",
@@ -3542,6 +3646,15 @@ export const FumaroleService = {
   /** Represents subscription to the control plane */
   subscribe: {
     path: "/fumarole.Fumarole/Subscribe",
+    requestStream: true,
+    responseStream: true,
+    requestSerialize: (value: ControlCommand): Buffer => Buffer.from(ControlCommand.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ControlCommand => ControlCommand.decode(value),
+    responseSerialize: (value: ControlResponse): Buffer => Buffer.from(ControlResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ControlResponse => ControlResponse.decode(value),
+  },
+  subscribeV2: {
+    path: "/fumarole.Fumarole/SubscribeV2",
     requestStream: true,
     responseStream: true,
     requestSerialize: (value: ControlCommand): Buffer => Buffer.from(ControlCommand.encode(value).finish()),
@@ -3576,11 +3689,13 @@ export interface FumaroleServer extends UntypedServiceImplementation {
   deleteConsumerGroup: handleUnaryCall<DeleteConsumerGroupRequest, DeleteConsumerGroupResponse>;
   createConsumerGroup: handleUnaryCall<CreateConsumerGroupRequest, CreateConsumerGroupResponse>;
   downloadBlock: handleServerStreamingCall<DownloadBlockShard, DataResponse>;
+  downloadBlockDataShard: handleServerStreamingCall<DownloadBlockShard, DataResponse>;
   /** Represents subscription to the data plane */
   subscribeData: handleBidiStreamingCall<DataCommand, DataResponse>;
   getChainTip: handleUnaryCall<GetChainTipRequest, GetChainTipResponse>;
   /** Represents subscription to the control plane */
   subscribe: handleBidiStreamingCall<ControlCommand, ControlResponse>;
+  subscribeV2: handleBidiStreamingCall<ControlCommand, ControlResponse>;
   version: handleUnaryCall<VersionRequest, VersionResponse>;
   getSlotRange: handleUnaryCall<GetSlotRangeRequest, GetSlotRangeResponse>;
 }
@@ -3652,6 +3767,15 @@ export interface FumaroleClient extends Client {
     metadata?: Metadata,
     options?: Partial<CallOptions>,
   ): ClientReadableStream<DataResponse>;
+  downloadBlockDataShard(
+    request: DownloadBlockShard,
+    options?: Partial<CallOptions>,
+  ): ClientReadableStream<DataResponse>;
+  downloadBlockDataShard(
+    request: DownloadBlockShard,
+    metadata?: Metadata,
+    options?: Partial<CallOptions>,
+  ): ClientReadableStream<DataResponse>;
   /** Represents subscription to the data plane */
   subscribeData(): ClientDuplexStream<DataCommand, DataResponse>;
   subscribeData(options: Partial<CallOptions>): ClientDuplexStream<DataCommand, DataResponse>;
@@ -3675,6 +3799,9 @@ export interface FumaroleClient extends Client {
   subscribe(): ClientDuplexStream<ControlCommand, ControlResponse>;
   subscribe(options: Partial<CallOptions>): ClientDuplexStream<ControlCommand, ControlResponse>;
   subscribe(metadata: Metadata, options?: Partial<CallOptions>): ClientDuplexStream<ControlCommand, ControlResponse>;
+  subscribeV2(): ClientDuplexStream<ControlCommand, ControlResponse>;
+  subscribeV2(options: Partial<CallOptions>): ClientDuplexStream<ControlCommand, ControlResponse>;
+  subscribeV2(metadata: Metadata, options?: Partial<CallOptions>): ClientDuplexStream<ControlCommand, ControlResponse>;
   version(
     request: VersionRequest,
     callback: (error: ServiceError | null, response: VersionResponse) => void,

--- a/typescript-sdk/src/runtime/grpc-slot-downloader.ts
+++ b/typescript-sdk/src/runtime/grpc-slot-downloader.ts
@@ -108,6 +108,7 @@ function do_download(this: GrpcSlotDownloader, args: DownloadTaskArgs) {
       this.totalDownloadedSlot += 1;
       this.downloadTaskResultObserver.next({
         kind: "Ok",
+        slot: args.downloadRequest.slot,
         completed: {
           slot: args.downloadRequest.slot,
           blockUid: args.downloadRequest.blockUid,
@@ -136,11 +137,11 @@ function do_download(this: GrpcSlotDownloader, args: DownloadTaskArgs) {
     } else {
       const result: DownloadTaskResult = {
         kind: "Err",
+        slot: args.downloadRequest.slot,
         err: {
           kind: err_kind,
           message: err,
         },
-        slot: args.downloadRequest.slot,
       };
       this.downloadTaskResultObserver.next(result);
     }
@@ -189,11 +190,11 @@ export function failingDownloadSlotObserverFactory(
       LOGGER.error("Download failed");
       ctx.downloadTaskResultObserver.next({
         kind: "Err",
+        slot: args.downloadRequest.slot,
         err: {
           kind: "FailedDownload",
           message: "Download failed",
         },
-        slot: args.downloadRequest.slot,
       });
     },
     error: (err: Error) => {

--- a/typescript-sdk/src/runtime/reactive_runtime.ts
+++ b/typescript-sdk/src/runtime/reactive_runtime.ts
@@ -82,8 +82,8 @@ export type DownloadTaskResultKind = "Ok" | "Err";
 export class DownloadTaskResult {
   constructor(
     public kind: DownloadTaskResultKind,
+    public slot: bigint,
     public completed?: CompletedDownloadBlockTask,
-    public slot?: bigint,
     public err?: DownloadBlockError,
   ) {}
 }
@@ -254,6 +254,15 @@ function onDownloadCompleted(
   } else {
     const slot = result.slot;
     const err = result.err;
+
+    if (err && err.kind === "BlockShardNotFound") {
+      LOGGER.warn(
+        `Block shard not found for slot ${slot}, treating as empty slot: ${err.message}`,
+      );
+      this.sm.makeSlotDownloadProgress(slot, 0);
+      return;
+    }
+
     throw new Error(`Failed to download slot ${slot}: ${err!.message}`);
   }
 }

--- a/typescript-sdk/src/runtime/state-machine.ts
+++ b/typescript-sdk/src/runtime/state-machine.ts
@@ -176,7 +176,7 @@ export class FumaroleSM {
 
   makeSlotDownloadProgress(
     slot: Slot,
-    shardIdx: FumeShardIdx,
+    shardIdx: FumeShardIdx | null,
   ): SlotDownloadState {
     // Update download progress for a given slot.
     const downloadProgress = this.inflightSlotShardDownload.get(slot);
@@ -184,7 +184,13 @@ export class FumaroleSM {
       throw new Error("Slot not in download");
     }
 
-    const downloadState = downloadProgress.doProgress(shardIdx);
+    let downloadState: SlotDownloadState = SlotDownloadState.Downloading;
+    if (shardIdx !== null) {
+      downloadState = downloadProgress.doProgress(shardIdx);
+    } else {
+      // If shardIdx is null, mark all shards as downloaded
+      downloadState = SlotDownloadState.Done;
+    }
 
     if (downloadState === SlotDownloadState.Done) {
       this.inflightSlotShardDownload.delete(slot);


### PR DESCRIPTION
- rust: Upgraded dependencies to use yellowstone-grpc v12.x.y.
- rust: minor bump for fume and client library.
- rust: made zstd compression enable by default and sharded download enable by default.
- typescript: remove the error raised in case a block not found in typescript client which prevents progression in the log.
- python: Better handle `mark_slot_download_progression` to support nullable `shard_idx`.