### PR TITLE
feat(client): add on_slot_not_found hook for Rust subscriptions

### DIFF
--- a/crates/yellowstone-fumarole-client/src/lib.rs
+++ b/crates/yellowstone-fumarole-client/src/lib.rs
@@ -287,6 +287,7 @@ use {
         },
     },
     semver::Version,
+    solana_clock::Slot,
     std::{
         collections::HashMap,
         num::{NonZeroU8, NonZeroUsize},
@@ -501,6 +502,10 @@ pub struct FumaroleSubscribeConfig {
     /// set to `true` by default.
     ///
     pub enable_sharded_block_download: bool,
+
+    /// Optional hook invoked when a slot's block data cannot be found during download.
+    /// This lets callers recover the slot via another RPC source such as `getBlock`.
+    pub on_slot_not_found: Option<Arc<dyn Fn(Slot) + Send + Sync>>,
 }
 
 impl Default for FumaroleSubscribeConfig {
@@ -519,6 +524,7 @@ impl Default for FumaroleSubscribeConfig {
             refresh_tip_stats_interval: DEFAULT_REFRESH_TIP_INTERVAL, // Default to 5 seconds
             no_commit: false,
             enable_sharded_block_download: true,
+            on_slot_not_found: None,
         }
     }
 }
@@ -851,6 +857,7 @@ impl FumaroleClient {
             no_commit: config.no_commit,
             stop: false,
             enable_sharded_block_download: use_sharded_downlaod,
+            on_slot_not_found: config.on_slot_not_found.clone(),
         };
         let fumarole_rt_jh = handle.spawn(tokio_rt.run());
         let fut = async move {

--- a/crates/yellowstone-fumarole-client/src/runtime/tokio.rs
+++ b/crates/yellowstone-fumarole-client/src/runtime/tokio.rs
@@ -96,6 +96,7 @@ pub(crate) struct TokioFumeDragonsmouthRuntime {
     pub no_commit: bool,
     pub stop: bool,
     pub enable_sharded_block_download: bool,
+    pub on_slot_not_found: Option<Arc<dyn Fn(Slot) + Send + Sync>>,
 }
 
 const DEFAULT_HISTORY_POLL_SIZE: i64 = 100;
@@ -138,6 +139,21 @@ impl From<SubscribeRequest> for BlockFilters {
 enum LoopInstruction {
     Continue,
     ErrorStop,
+}
+
+fn spawn_slot_not_found_hook(
+    hook: Option<Arc<dyn Fn(Slot) + Send + Sync>>,
+    slot: Slot,
+) -> Option<task::JoinHandle<()>> {
+    hook.map(|hook| {
+        task::spawn_blocking(move || {
+            if let Err(err) =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| (hook)(slot)))
+            {
+                tracing::error!("on_slot_not_found panicked for slot {slot}: {err:?}");
+            }
+        })
+    })
 }
 
 impl TokioFumeDragonsmouthRuntime {
@@ -242,7 +258,6 @@ impl TokioFumeDragonsmouthRuntime {
                 }
             }
             DownloadTaskResult::Err { slot, err } => {
-                // TODO add option to let user decide what to do, by default let it crash
                 match err {
                     DownloadBlockError::OutletDisconnected => {
                         // Will be handled in the main loop.
@@ -250,6 +265,7 @@ impl TokioFumeDragonsmouthRuntime {
                     }
                     DownloadBlockError::FailedDownload(h2_err) => {
                         if h2_err.code() == Code::NotFound {
+                            let _ = spawn_slot_not_found_hook(self.on_slot_not_found.clone(), slot);
                             self.sm.make_slot_download_progress(slot, None);
                             tracing::error!("slot {slot} not found, skipping...");
                         } else {


### PR DESCRIPTION
## Summary

  This PR adds an optional `on_slot_not_found` hook to the Rust client subscribe configuration.

  Changes:
  - add `on_slot_not_found` to `FumaroleSubscribeConfig`
  - default the hook to `None` to preserve existing behavior
  - wire the hook into `TokioFumeDragonsmouthRuntime`
  - invoke the hook when a slot download fails with gRPC `Code::NotFound`

  ## Motivation

  The Python SDK already exposes an `on_slot_not_found` callback so callers can recover a missing slot through another RPC source such as `getBlock`.

  Before this change, the Rust client only logged the not-found condition and marked the slot as skipped. That meant Rust users had no programmatic recovery
  path.

  This PR closes that feature-parity gap for the Rust client.

  ## Testing

  Verified with:

  - `cargo fmt --all`
  - `cargo clippy --all-targets --tests -- -Dwarnings`
  - `cargo test -p yellowstone-fumarole-client --lib`