### PR TITLE
fix(ts-sdk): add gcInterval config

### DIFF
--- a/typescript-sdk/src/index.ts
+++ b/typescript-sdk/src/index.ts
@@ -409,6 +409,7 @@ export class FumaroleClient {
       controlPlaneResponseObservable: ctrlPlaneResponseObservable,
       sm,
       commitIntervalMillis: config.commitInterval,
+      gcInterval: config.gcInterval,
       maxConcurrentDownload: config.concurrentDownloadLimit,
       initialSubscribeRequest,
       subscribeRequestObservable: subscribeRequestSub.asObservable(),

--- a/typescript-sdk/src/runtime/reactive_runtime.ts
+++ b/typescript-sdk/src/runtime/reactive_runtime.ts
@@ -134,6 +134,7 @@ export type FumaroleRuntimeArgs = {
   controlPlaneResponseObservable: Observable<ControlResponse>;
   sm: FumaroleSM;
   commitIntervalMillis: number;
+  gcInterval: number;
   maxConcurrentDownload: number;
   initialSubscribeRequest: SubscribeRequest;
   subscribeRequestObservable: Observable<SubscribeRequest>;
@@ -531,6 +532,7 @@ export function fumaroleObservable(
     downloadTaskResultObservable,
     controlPlaneResponseObservable,
     commitIntervalMillis,
+    gcInterval,
     sm,
     maxConcurrentDownload,
     initialSubscribeRequest,
@@ -601,7 +603,7 @@ export function fumaroleObservable(
     const ctx: FumaroleRuntimeCtx = {
       currentTick: 0,
       sm,
-      gcInterval: 1000,
+      gcInterval,
       maxConcurrentDownload,
       lastCommit: Date.now(),
       inflightDownloads: new Map(),


### PR DESCRIPTION
## Summary

  This PR wires `gcInterval` from the public TypeScript SDK subscribe config into the runtime.

  Changes:
  - add `gcInterval` to `FumaroleRuntimeArgs`
  - pass `config.gcInterval` when constructing runtime args
  - replace the hardcoded runtime value `gcInterval: 1000` with the configured value

  ## Motivation

  The TypeScript SDK already exposes `gcInterval` in `FumaroleSubscribeConfig`, so callers can reasonably expect changing it to affect runtime behavior.

  Before this change, the runtime ignored the configured value and always used a hardcoded `1000`, which made the public config ineffective.

  This PR fixes that config plumbing bug so the runtime honors the caller-provided garbage collection interval.