### PR TITLE
ci: add goreleaser config check workflow (PLA-457)

### DIFF
--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -1,0 +1,26 @@
+---
+name: GoReleaser config check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+  workflow_dispatch:
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: goreleaser check
+        run: goreleaser check

--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
           install-only: true
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/goreleaser-config-check.yaml` to validate `.goreleaser.yaml` on PRs that touch it
- Uses GitHub-hosted runner (`ubuntu-22.04`) as required for public repos per PLA-412

Note: `.goreleaser.yaml` was already merged to main in #53. This PR completes the Gen 2 migration by adding the config validation workflow.

Part of PLA-412 / PLA-457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)