### PR TITLE
ci: pin goreleaser project_name and scope Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ permissions:
 
 on:
   push:
+    paths-ignore:
+      - '.goreleaser.yaml'
+      - '.github/workflows/goreleaser-config-check.yaml'
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE*'
   workflow_dispatch:
 
 env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 version: 2
 
+project_name: yellowstone-fumarole
+
 before:
     hooks:
         - bash -c 'if [ -n "$GITHUB_ENV" ]; then echo "YELLOWSTONE_GRPC_CLIENT_VERSION=$(cargo --quiet metadata --format-version 1 | jq -r '\''.packages[] | select(.name=="yellowstone-grpc-client") | .version'\'')" >> "$GITHUB_ENV"; fi'


### PR DESCRIPTION
## Summary

- **`.goreleaser.yaml`**: pin `project_name: yellowstone-fumarole`. Without it, the Binaries-ci centralized build resolved `{{ .ProjectName }}` to `Binaries-ci` (the workflow repo), causing the first `rust-client-v0.4.1-rc1` build to upload to `gs://nomad-triton-test/Binaries-ci/v0.4.1-rc1/…` instead of the `yellowstone-fumarole/` prefix the nomad jobs expect. Setting `project_name` explicitly keeps the bucket layout consistent regardless of how the goreleaser config is loaded.
- **`.github/workflows/test.yml`**: add `paths-ignore` so pushes that only change `.goreleaser.yaml`, the goreleaser config-check workflow, markdown / docs, or license files no longer trigger the full Rust build + clippy + cargo-deny + fmt pipeline.

After merge, re-running the Binaries-ci dispatch for `rust-client-v0.4.1-rc1` will place artifacts at `gs://nomad-triton-test/yellowstone-fumarole/v0.4.1-rc1/fume-linux-amd64`.

Initial failed run (wrong path): https://github.com/rpcpool/Binaries-ci/actions/runs/25802129678